### PR TITLE
Restore the nRF5xGattClient for S130 builds

### DIFF
--- a/source/nRF5xn.h
+++ b/source/nRF5xn.h
@@ -49,7 +49,7 @@ public:
         return nRF5xGattServer::getInstance();
     };
     virtual GattClient &getGattClient() {
-#if defined(YOTTA_CFG_MICROBIT_S130)
+#if defined(YOTTA_CFG_MICROBIT_S130) && (YOTTA_CFG_MICROBIT_S130 == 1)
         return nRF5xGattClient::getInstance();
 #else
         /* S110 doesn't require GattClient to be implemented; save 300 bytes by removing this static overhead. */

--- a/source/nRF5xn.h
+++ b/source/nRF5xn.h
@@ -49,12 +49,12 @@ public:
         return nRF5xGattServer::getInstance();
     };
     virtual GattClient &getGattClient() {
-        #if defined(MCU_NORDIC_16K_S110) || defined(MCU_NORDIC_32K_S110)
-            /* S110 doesn't require GattClient to be implemented; save 300 bytes by removing this static overhead. */
-            return GattClient::getInstance();
-        #else
-            return nRF5xGattClient::getInstance();
-        #endif
+#if defined(YOTTA_CFG_MICROBIT_S130)
+        return nRF5xGattClient::getInstance();
+#else
+        /* S110 doesn't require GattClient to be implemented; save 300 bytes by removing this static overhead. */
+        return GattClient::getInstance();
+#endif
     }
     virtual const SecurityManager &getSecurityManager() const {
         return nRF5xSecurityManager::getInstance();

--- a/source/nRF5xn.h
+++ b/source/nRF5xn.h
@@ -49,7 +49,12 @@ public:
         return nRF5xGattServer::getInstance();
     };
     virtual GattClient &getGattClient() {
-        return GattClient::getInstance();
+        #if defined(MCU_NORDIC_16K_S110) || defined(MCU_NORDIC_32K_S110)
+            /* S110 doesn't require GattClient to be implemented; save 300 bytes by removing this static overhead. */
+            return GattClient::getInstance();
+        #else
+            return nRF5xGattClient::getInstance();
+        #endif
     }
     virtual const SecurityManager &getSecurityManager() const {
         return nRF5xSecurityManager::getInstance();


### PR DESCRIPTION
For S130 builds, when using the micro:bit as a central device we do actually need the real GattClient, at the expense of the extra memory.
